### PR TITLE
feat(opentelemetry-plugin-react-load): updating flow spans + tests

### DIFF
--- a/plugins/web/opentelemetry-plugin-react-load/package.json
+++ b/plugins/web/opentelemetry-plugin-react-load/package.json
@@ -9,7 +9,7 @@
     "clean": "rimraf build/*",
     "lint": "gts check",
     "lint:fix": "gts fix",
-    "codecov:browser": "nyc report --reporter=json && codecov -f coverage/*.json -p ../../",
+    "codecov:browser": "nyc report --reporter=json && codecov -f coverage/*.json -p ../../../",
     "precompile": "tsc --version",
     "version:update": "node ../../../scripts/version-update.js",
     "compile": "npm run version:update && tsc -p .",

--- a/plugins/web/opentelemetry-plugin-react-load/src/enums/AttributeNames.ts
+++ b/plugins/web/opentelemetry-plugin-react-load/src/enums/AttributeNames.ts
@@ -18,6 +18,6 @@ export enum AttributeNames {
   MOUNTING_SPAN = 'reactLoad: mounting',
   UPDATING_SPAN = 'reactLoad: updating',
   LOCATION_URL = 'location',
-  REACT_NAME = 'react component name',
-  REACT_STATE = 'react component state'
+  REACT_NAME = 'react_component_name',
+  REACT_STATE = 'react_component_state'
 }

--- a/plugins/web/opentelemetry-plugin-react-load/src/enums/AttributeNames.ts
+++ b/plugins/web/opentelemetry-plugin-react-load/src/enums/AttributeNames.ts
@@ -16,6 +16,8 @@
 
 export enum AttributeNames {
   MOUNTING_SPAN = 'reactLoad: mounting',
+  UPDATING_SPAN = 'reactLoad: updating',
   LOCATION_URL = 'location',
-  REACT_NAME = 'react component name'
+  REACT_NAME = 'react component name',
+  REACT_STATE = 'react component state'
 }

--- a/plugins/web/opentelemetry-plugin-react-load/src/reactLoad.ts
+++ b/plugins/web/opentelemetry-plugin-react-load/src/reactLoad.ts
@@ -23,7 +23,12 @@ import { VERSION } from './version';
 import * as React from 'react';
 import {
   RenderFunction,
-  ComponentDidMountFunction
+  ComponentDidMountFunction,
+  ComponentDidUpdateFunction,
+  ShouldComponentUpdateFunction,
+  SetStateFunction,
+  ForceUpdateFunction,
+  GetSnapshotBeforeUpdateFunction
 } from './types';
 /**
  * This class represents a react lifecycle plugin
@@ -58,11 +63,7 @@ export class ReactLoad extends BasePlugin<unknown> {
     name: string
   ): api.Span | undefined {
     return this._tracer.startSpan(name, {
-      attributes: {
-        [GeneralAttribute.COMPONENT]: this.moduleName,
-        [AttributeNames.LOCATION_URL]: window.location.href,
-        [AttributeNames.REACT_NAME]: react.constructor.name,
-      },
+      attributes: this._getAttributes(react),
       parent: this._getParentSpan(react),
     });
   }
@@ -74,12 +75,27 @@ export class ReactLoad extends BasePlugin<unknown> {
    */
   private _createSpan(react: React.Component, name: string): api.Span | undefined {
     return this._tracer.startSpan(name, {
-      attributes: {
-        [GeneralAttribute.COMPONENT]: this.moduleName,
-        [AttributeNames.LOCATION_URL]: window.location.href,
-        [AttributeNames.REACT_NAME]: react.constructor.name,
-      },
+      attributes: this._getAttributes(react)
     });
+  }
+
+   /**
+   * Returns attributes object for spans
+   * @param react React component currently being instrumented
+   **/
+  private _getAttributes(react: React.Component) {
+    let state = "";
+    try{
+      state = JSON.stringify(react.state)
+    } catch {
+      state = "state could not be turned into string"
+    }
+    return {
+      [GeneralAttribute.COMPONENT]: this.moduleName,
+      [AttributeNames.LOCATION_URL]: window.location.href,
+      [AttributeNames.REACT_NAME]: react.constructor.name,
+      [AttributeNames.REACT_STATE]: state
+    }
   }
 
    /**
@@ -152,20 +168,182 @@ export class ReactLoad extends BasePlugin<unknown> {
   }
 
   /**
+   * Patches the setState function
+   */
+  private _patchSetState(){
+    return (original: SetStateFunction): SetStateFunction => {
+      const plugin = this;
+      return function patchSetState(
+        this: React.Component,
+        ...args
+      ): void {
+        const span = plugin._createSpanWithParent(this, 'setState()');
+        const apply = original.apply(this, args);
+        if (span) {
+          span.end();
+        }
+        
+        return apply;
+      };
+    };
+  }
+
+   /**
+   * Patches the forceUpdate function
+   */
+  private _patchForceUpdate(){
+    return (original: ForceUpdateFunction): ForceUpdateFunction => {
+      const plugin = this;
+      return function patchForceUpdate(
+        this: React.Component,
+        ...args
+      ): void {
+        const span = plugin._createSpanWithParent(this, 'forceUpdate()');
+        const apply = original.apply(this, args);
+        if (span) {
+          span.end();
+        }
+        
+        return apply;
+      };
+    };
+  }
+
+  /**
+   * Patches the shouldComponentUpdate lifecycle method
+   */
+  private _patchShouldComponentUpdate(){
+    return (original: ShouldComponentUpdateFunction): ShouldComponentUpdateFunction => {
+      const plugin = this;
+      if (!original) {
+        this._logger.debug(
+          'shouldComponentUpdate function was undefined, should always be defined when patching.'
+        );
+        return;
+      }
+
+      return function patchShouldComponentUpdate(
+        this: React.Component,
+        ...args
+      ): boolean {
+        const span = plugin._createSpanWithParent(this, 'shouldComponentUpdate');
+        const apply = original.apply(this, args);
+        if (span) {
+          span.end();
+        }
+        // if shouldComponentUpdate returns false, the component does not get 
+        // updated and no other lifecycle methods get called
+        if(apply === false){
+          const updatingSpan = plugin._getParentSpan(this);
+          if (updatingSpan) {
+            updatingSpan.updateName(AttributeNames.UPDATING_SPAN);
+            updatingSpan.end();
+            plugin._parentSpanMap.delete(this);
+          }
+        }
+        
+        return apply;
+      };
+    };
+  }
+
+
+  /**
+   * Patches the shouldComponentUpdate lifecycle method
+   */
+  private _patchGetSnapshotBeforeUpdate(){
+    return (original: GetSnapshotBeforeUpdateFunction): GetSnapshotBeforeUpdateFunction => {
+      const plugin = this;
+      if (!original) {
+        this._logger.debug(
+          'getSnapshotBeforeUpdate function was undefined, should always be defined when patching.'
+        );
+        return;
+      }
+
+      return function patchGetSnapshotBeforeUpdate(
+        this: React.Component,
+        ...args
+      ): any {
+        const span = plugin._createSpanWithParent(this, 'getSnapshotBeforeUpdate');
+        const apply = original.apply(this, args);
+        if (span) {
+          span.end();
+        }
+        
+        return apply;
+      };
+    };
+  }
+
+  /**
+   * Patches the componentDidUpdate lifecycle method
+   */
+  private _patchComponentDidUpdate(){
+    return (original: ComponentDidUpdateFunction): ComponentDidUpdateFunction => {
+      const plugin = this;
+      if (!original) {
+        this._logger.debug(
+          'componentDidUpdate function was undefined, should always be defined when patching.'
+        );
+        return;
+      }
+
+      return function patchComponentDidUpdate(
+        this: React.Component,
+        ...args
+      ): void {
+        const span = plugin._createSpanWithParent(this, 'componentDidUpdate');
+        const apply = original.apply(this, args);
+        if (span) {
+          span.end();
+        }
+        const updatingSpan = plugin._getParentSpan(this);
+        if (updatingSpan) {
+          updatingSpan.updateName(AttributeNames.UPDATING_SPAN);
+          updatingSpan.end();
+          plugin._parentSpanMap.delete(this);
+        }
+        return apply;
+      };
+    };
+  }
+
+  /**
    * implements patch function
    */
   protected patch() {
     this._logger.debug('applying patch to', this.moduleName, this.version);
     this._reactComponents.forEach(prototype => {
+      if (isWrapped(prototype.render)) {
+        shimmer.unwrap(prototype, 'render');
+        this._logger.debug('removing previous patch from method render');
+      }
       if (isWrapped(prototype.componentDidMount)) {
         shimmer.unwrap(prototype, 'componentDidMount');
         this._logger.debug(
           'removing previous patch from method componentDidMount'
         );
       }
-      if (isWrapped(prototype.render)) {
-        shimmer.unwrap(prototype, 'render');
-        this._logger.debug('removing previous patch from method render');
+      if (isWrapped(prototype.shouldComponentUpdate)) {
+        shimmer.unwrap(prototype, 'shouldComponentUpdate');
+        this._logger.debug('removing previous patch from method shouldComponentUpdate');
+      }
+      if (isWrapped(prototype.getSnapshotBeforeUpdate)) {
+        shimmer.unwrap(prototype, 'getSnapshotBeforeUpdate');
+        this._logger.debug('removing previous patch from method getSnapshotBeforeUpdate');
+      }
+      if(isWrapped(prototype.setState)){
+        shimmer.unwrap(prototype, 'setState');
+        this._logger.debug('removing previous patch from method setState');
+      }
+      if(isWrapped(prototype.forceUpdate)){
+        shimmer.unwrap(prototype, 'forceUpdate');
+        this._logger.debug('removing previous patch from method forceUpdate');
+      }
+      if (isWrapped(prototype.componentDidUpdate)) {
+        shimmer.unwrap(prototype, 'componentDidUpdate');
+        this._logger.debug('removing previous patch from method componentDidUpdate');
       }
 
       // Lifecycle methods must exist when patching, even if not defined in component
@@ -177,6 +355,15 @@ export class ReactLoad extends BasePlugin<unknown> {
       if (!prototype.componentDidMount) {
         prototype.componentDidMount = () => {};
       }
+      if (!prototype.shouldComponentUpdate) {
+        prototype.shouldComponentUpdate = () => { return true; };
+      }
+      if (!prototype.getSnapshotBeforeUpdate) {
+        prototype.getSnapshotBeforeUpdate = () => { return null; };
+      }
+      if (!prototype.componentDidUpdate) {
+        prototype.componentDidUpdate = () => {};
+      }
 
       shimmer.wrap(prototype, 'render', this._patchRender());
       shimmer.wrap(
@@ -184,6 +371,11 @@ export class ReactLoad extends BasePlugin<unknown> {
         'componentDidMount',
         this._patchComponentDidMount()
       );
+      shimmer.wrap(prototype, 'setState', this._patchSetState());
+      shimmer.wrap(prototype, 'forceUpdate', this._patchForceUpdate());
+      shimmer.wrap(prototype, 'shouldComponentUpdate', this._patchShouldComponentUpdate());
+      shimmer.wrap(prototype, 'getSnapshotBeforeUpdate', this._patchGetSnapshotBeforeUpdate());
+      shimmer.wrap(prototype, 'componentDidUpdate', this._patchComponentDidUpdate());
     });
     return this._moduleExports;
   }
@@ -196,7 +388,14 @@ export class ReactLoad extends BasePlugin<unknown> {
 
     this._reactComponents.forEach(prototype => {
       shimmer.unwrap(prototype, 'render');
+      
       shimmer.unwrap(prototype, 'componentDidMount');
+  
+      shimmer.unwrap(prototype, 'setState');
+      shimmer.unwrap(prototype, 'forceUpdate');
+      shimmer.unwrap(prototype, 'shouldComponentUpdate');
+      shimmer.unwrap(prototype, 'getSnapshotBeforeUpdate');
+      shimmer.unwrap(prototype, 'componentDidUpdate');
     });
 
     this._parentSpanMap = new WeakMap<React.Component, api.Span | undefined>();

--- a/plugins/web/opentelemetry-plugin-react-load/src/types.ts
+++ b/plugins/web/opentelemetry-plugin-react-load/src/types.ts
@@ -25,3 +25,28 @@
  * method "componentDidMount" from React.Component
  */
  export type ComponentDidMountFunction = (() => void) | undefined;
+
+ /*
+ * method "componentDidUpdate" from React.Component
+ */
+export type ComponentDidUpdateFunction = ((prevProps: Readonly<{}>, prevState: Readonly<{}>, snapshot?: any) => void) | undefined;
+
+ /*
+ * method "shouldComponentUpdate" from React.Component
+ */
+export type ShouldComponentUpdateFunction = ((nextProps: Readonly<{}>, nextState: Readonly<{}>, nextContext: any) => boolean) | undefined;
+
+ /*
+ * method "setState" from React.Component
+ */
+export type SetStateFunction = <K extends never>(state: {} | ((prevState: Readonly<{}>, props: Readonly<{}>) => {} | Pick<{}, K> | null) | Pick<{}, K> | null, callback?: (() => void) | undefined) => void;
+
+/*
+ * method "setState" from React.Component
+ */
+export type ForceUpdateFunction = (callback?: (() => void) | undefined) => void;
+
+/*
+ * method "getSnapshotBeforeUpdate" from React.Component
+ */
+export type GetSnapshotBeforeUpdateFunction = ((prevProps: Readonly<{}>, prevState: Readonly<{}>) => any) | undefined;

--- a/plugins/web/opentelemetry-plugin-react-load/test/reactLoad.test.ts
+++ b/plugins/web/opentelemetry-plugin-react-load/test/reactLoad.test.ts
@@ -19,35 +19,39 @@ import {
     Logger,
     propagation,
   } from '@opentelemetry/api';
-  import {
-    ConsoleLogger,
-    B3Propagator,
-    isWrapped
-  } from '@opentelemetry/core';
-  import {
-    BasicTracerProvider,
-    SimpleSpanProcessor,
-    SpanExporter,
-    ReadableSpan,
-  } from '@opentelemetry/tracing';
-  import {
-    StackContextManager,
-  } from '@opentelemetry/web';
-  import {
-    GeneralAttribute,
-  } from '@opentelemetry/semantic-conventions';
-  import * as assert from 'assert';
-  import * as sinon from 'sinon';
-  import { ReactLoad } from '../src';
-  import AllLifecycles from './test-react-components/AllLifecycles';
-  import MissingRender from './test-react-components/MissingRender';
-  import MissingComponentDidMount from './test-react-components/MissingComponentDidMount';
-  import * as React from "react";
-  import * as ReactDOM from "react-dom";
-  import { act } from 'react-dom/test-utils';
+import {
+  ConsoleLogger,
+  B3Propagator,
+  isWrapped
+} from '@opentelemetry/core';
+import {
+  BasicTracerProvider,
+  SimpleSpanProcessor,
+  SpanExporter,
+  ReadableSpan,
+} from '@opentelemetry/tracing';
+import {
+  StackContextManager,
+} from '@opentelemetry/web';
+import {
+  GeneralAttribute,
+} from '@opentelemetry/semantic-conventions';
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import { ReactLoad } from '../src';
+import AllLifecycles from './test-react-components/AllLifecycles';
+import MissingRender from './test-react-components/MissingRender';
+import MissingComponentDidMount from './test-react-components/MissingComponentDidMount';
+import MissingShouldComponentUpdate from './test-react-components/MissingShouldComponentUpdate';
+import MissingGetSnapshotBeforeUpdate from './test-react-components/MissingGetSnapshotBeforeUpdate';
+import MissingComponentDidUpdate from './test-react-components/MissingComponentDidUpdate';
+import ShouldComponentUpdateFalse from './test-react-components/ShouldComponentUpdateFalse';
+import * as React from "react";
+import * as ReactDOM from "react-dom";
+import { act } from 'react-dom/test-utils';
 import { AttributeNames } from '../src/enums/AttributeNames';
 
-  export class DummyExporter implements SpanExporter {
+export class DummyExporter implements SpanExporter {
     export(spans: any) {}
     shutdown() {}
   }
@@ -97,6 +101,9 @@ import { AttributeNames } from '../src/enums/AttributeNames';
       { component: AllLifecycles, testName: "when every lifecycle method is defined in the source code"},
       { component: MissingRender, testName: "when render is NOT defined in the source code"},
       { component: MissingComponentDidMount, testName: "when componentDidMount is NOT defined in the source code"},
+      { component: MissingShouldComponentUpdate, testName: "when shouldComponentUpdate is NOT defined in the source code"},
+      { component: MissingGetSnapshotBeforeUpdate, testName: "when getSnapshotBeforeUpdate is NOT defined in the source code"},
+      { component: MissingComponentDidUpdate, testName: "when componentDidUpdate is NOT defined in the source code"}
     ];
 
     componentTestCases.forEach(testCase => {
@@ -113,30 +120,50 @@ import { AttributeNames } from '../src/enums/AttributeNames';
         it('should always have defined lifecycle methods', () => {
           assert.ok(component.prototype.render, 'render is not defined');
           assert.ok(component.prototype.componentDidMount, 'componentDidMount is not defined');
+
+          assert.ok(component.prototype.shouldComponentUpdate, 'shouldComponentUpdate is not defined');
+          assert.ok(component.prototype.getSnapshotBeforeUpdate, 'getSnapshotBeforeUpdate is not defined');
+          assert.ok(component.prototype.componentDidUpdate, 'componentDidUpdate is not defined');
         });
 
-        it('should wrap render()', () => {
-          assert.ok(isWrapped(component.prototype.render));
+        it('should wrap functions', () => {
+          assert.ok(isWrapped(component.prototype.render), 'render function is not wrapped');
+          assert.ok(isWrapped(component.prototype.componentDidMount), 'componentDidMount function is not wrapped');
+          assert.ok(isWrapped(component.prototype.shouldComponentUpdate), 'shouldComponentUpdate function is not wrapped');
+          assert.ok(isWrapped(component.prototype.getSnapshotBeforeUpdate), 'getSnapshotBeforeUpdate function is not wrapped');
+          assert.ok(isWrapped(component.prototype.componentDidUpdate), 'componentDidUpdate function is not wrapped');
+          assert.ok(isWrapped(component.prototype.setState), 'setState function is not wrapped');
+          assert.ok(isWrapped(component.prototype.forceUpdate), 'forceUpdate function is not wrapped');
+          
           reactPlugin.enable(moduleExports, provider, logger);
-          assert.ok(isWrapped(component.prototype.render));
+          
+          assert.ok(isWrapped(component.prototype.render), 'render function is not wrapped');
+          assert.ok(isWrapped(component.prototype.componentDidMount), 'componentDidMount function is not wrapped');
+          assert.ok(isWrapped(component.prototype.shouldComponentUpdate), 'shouldComponentUpdate function is not wrapped');
+          assert.ok(isWrapped(component.prototype.getSnapshotBeforeUpdate), 'getSnapshotBeforeUpdate function is not wrapped');
+          assert.ok(isWrapped(component.prototype.componentDidUpdate), 'componentDidUpdate function is not wrapped');
+          assert.ok(isWrapped(component.prototype.setState), 'setState function is not wrapped');
+          assert.ok(isWrapped(component.prototype.forceUpdate), 'forceUpdate function is not wrapped');
         });
 
-        it('should unwrap render()', () => {
-          assert.ok(isWrapped(component.prototype.render));
+        it('should unwrap functions', () => {
+          assert.ok(isWrapped(component.prototype.render), 'render function is not wrapped');
+          assert.ok(isWrapped(component.prototype.componentDidMount), 'componentDidMount function is not wrapped');
+          assert.ok(isWrapped(component.prototype.shouldComponentUpdate), 'shouldComponentUpdate function is not wrapped');
+          assert.ok(isWrapped(component.prototype.getSnapshotBeforeUpdate), 'getSnapshotBeforeUpdate function is not wrapped');
+          assert.ok(isWrapped(component.prototype.componentDidUpdate), 'componentDidUpdate function is not wrapped');
+          assert.ok(isWrapped(component.prototype.setState), 'setState function is not wrapped');
+          assert.ok(isWrapped(component.prototype.forceUpdate), 'forceUpdate function is not wrapped');
+          
           reactPlugin.disable();
-          assert.ok(!isWrapped(component.prototype.render));
-        });
-
-        it('should wrap componentDidMount()', () => {
-          assert.ok(isWrapped(component.prototype.componentDidMount));
-          reactPlugin.enable(moduleExports, provider, logger);
-          assert.ok(isWrapped(component.prototype.componentDidMount));
-        });
-
-        it('should unwrap componentDidMount()', () => {
-          assert.ok(isWrapped(component.prototype.componentDidMount));
-          reactPlugin.disable();
-          assert.ok(!isWrapped(component.prototype.componentDidMount));
+          
+          assert.ok(!isWrapped(component.prototype.render), 'render function is not unwrapped');
+          assert.ok(!isWrapped(component.prototype.componentDidMount), 'componentDidMount function is not unwrapped');
+          assert.ok(!isWrapped(component.prototype.shouldComponentUpdate), 'shouldComponentUpdate function is not unwrapped');
+          assert.ok(!isWrapped(component.prototype.getSnapshotBeforeUpdate), 'getSnapshotBeforeUpdate function is not unwrapped');
+          assert.ok(!isWrapped(component.prototype.componentDidUpdate), 'componentDidUpdate function is not unwrapped');
+          assert.ok(!isWrapped(component.prototype.setState), 'setState function is not unwrapped');
+          assert.ok(!isWrapped(component.prototype.forceUpdate), 'forceUpdate function is not unwrapped');
         });
 
         describe('AND component is mounting', () => {
@@ -174,6 +201,8 @@ import { AttributeNames } from '../src/enums/AttributeNames';
               mountingSpan.spanContext.spanId, 
               'componentDidMount span is not a child of the mounting span'
             );
+
+            assert.strictEqual(exportSpy.args.length, 3, `total number of spans is wrong`);
           });
 
           it('spans should have correct name', () => {
@@ -208,9 +237,302 @@ import { AttributeNames } from '../src/enums/AttributeNames';
                 `attributes ${AttributeNames.REACT_NAME} is not defined for span "${span.name}"`
               );
 
-              assert.strictEqual(keys.length, 3, `number of attributes is wrong for span "${span.name}"`);
+              assert.ok(
+                attributes[keys[3]] !== '',
+                `attributes ${AttributeNames.REACT_STATE} is not defined for span "${span.name}"`
+              );
+
+              assert.strictEqual(keys.length, 4, `number of attributes is wrong for span "${span.name}"`);
             });
           });
+        });
+
+        describe('AND component is updated by calling setState()', () => {
+          beforeEach(() => {
+            rootContainer = document.createElement("div");
+            document.body.appendChild(rootContainer);
+            var reactElement = React.createElement(component, null, null);
+            act(() => {
+              let reactComponent = ReactDOM.render(reactElement, rootContainer);
+              reactComponent.setState({test: 'newState'});
+            });
+          });
+
+          afterEach(() => {
+            document.body.removeChild(rootContainer);
+            rootContainer = null;
+          });
+
+          it('should export spans setState(), shouldComponentUpdate, render, getSnapshotBeforeUpdate, and componentDidUpdate as children', () => {
+            const setStateSpan: ReadableSpan = exportSpy.args[3][0][0];
+            const shouldComponentUpdateSpan: ReadableSpan = exportSpy.args[4][0][0];
+            const renderSpan: ReadableSpan = exportSpy.args[5][0][0];
+            const getSnapshotBeforeUpdateSpan: ReadableSpan = exportSpy.args[6][0][0];
+            const componentDidUpdateSpan: ReadableSpan = exportSpy.args[7][0][0];
+            const updatingSpan: ReadableSpan = exportSpy.args[8][0][0];
+     
+            assert.equal(
+              updatingSpan.parentSpanId, 
+              undefined, 
+              'updating span is should not have a parent'
+            );
+            assert.equal(
+              setStateSpan.parentSpanId, 
+              updatingSpan.spanContext.spanId, 
+              'setState span is not a child of the updating span'
+            );
+            assert.equal(
+              shouldComponentUpdateSpan.parentSpanId, 
+              updatingSpan.spanContext.spanId, 
+              'shouldComponentUpdate span is not a child of the updating span'
+            );
+            assert.equal(
+              renderSpan.parentSpanId, 
+              updatingSpan.spanContext.spanId, 
+              'render span is not a child of the updating span'
+            );
+            assert.equal(
+              getSnapshotBeforeUpdateSpan.parentSpanId, 
+              updatingSpan.spanContext.spanId, 
+              'getSnapshotBeforeUpdate span is not a child of the updating span'
+            );
+            assert.equal(
+              componentDidUpdateSpan.parentSpanId,
+              updatingSpan.spanContext.spanId, 
+              'componentDidUpdate span is not a child of the updating span'
+            );
+
+            assert.strictEqual(exportSpy.args.length, 9, `total number of spans is wrong`);
+          });
+
+          it('spans should have correct name', () => {
+            const setStateSpan: ReadableSpan = exportSpy.args[3][0][0];
+            const shouldComponentUpdateSpan: ReadableSpan = exportSpy.args[4][0][0];
+            const renderSpan: ReadableSpan = exportSpy.args[5][0][0];
+            const getSnapshotBeforeUpdateSpan: ReadableSpan = exportSpy.args[6][0][0];
+            const componentDidUpdateSpan: ReadableSpan = exportSpy.args[7][0][0];
+            const updatingSpan: ReadableSpan = exportSpy.args[8][0][0];
+
+            assert.equal(updatingSpan.name, 'reactLoad: updating', 'updating span has wrong name');
+            assert.equal(setStateSpan.name, 'setState()', 'setState span has wrong name');
+            assert.equal(shouldComponentUpdateSpan.name, 'shouldComponentUpdate', 'shouldComponentUpdate span has wrong name');
+            assert.equal(renderSpan.name, 'render', 'render span has wrong name');
+            assert.equal(getSnapshotBeforeUpdateSpan.name, 'getSnapshotBeforeUpdate', 'getSnapshotBeforeUpdate span has wrong name');
+            assert.equal(componentDidUpdateSpan.name, 'componentDidUpdate', 'componentDidUpdate span has wrong name');
+          });
+
+          it('spans should have correct attributes', () => {
+            const spans: [] = exportSpy.args;
+            spans.forEach(element => {
+              const span: ReadableSpan = element[0][0];
+              const attributes = span.attributes;
+              const keys = Object.keys(attributes);
+
+              assert.ok(
+                attributes[keys[0]] !== '',
+                `attributes ${GeneralAttribute.COMPONENT} is not defined for span "${span.name}"`
+              );
+
+              assert.ok(
+                attributes[keys[1]] !== '',
+                `attributes ${AttributeNames.LOCATION_URL} is not defined for span "${span.name}"`
+              );
+
+              assert.ok(
+                attributes[keys[2]] !== '',
+                `attributes ${AttributeNames.REACT_NAME} is not defined for span "${span.name}"`
+              );
+
+              assert.ok(
+                attributes[keys[3]] !== '',
+                `attributes ${AttributeNames.REACT_STATE} is not defined for span "${span.name}"`
+              );
+
+              assert.strictEqual(keys.length, 4, `number of attributes is wrong for span "${span.name}"`);
+            });
+          });
+        });
+
+        describe('AND component is updated by calling forceUpdate()', () => {
+          beforeEach(() => {
+            rootContainer = document.createElement("div");
+            document.body.appendChild(rootContainer);
+            var reactElement = React.createElement(component, null, null);
+            act(() => {
+              let reactComponent = ReactDOM.render(reactElement, rootContainer);
+              reactComponent.forceUpdate();
+            });
+          });
+
+          afterEach(() => {
+            document.body.removeChild(rootContainer);
+            rootContainer = null;
+          });
+
+          it('should export spans forceUpdate(), render, getSnapshotBeforeUpdate, and componentDidUpdate as children', () => {
+            const forceUpdateSpan: ReadableSpan = exportSpy.args[3][0][0];
+            const renderSpan: ReadableSpan = exportSpy.args[4][0][0];
+            const getSnapshotBeforeUpdateSpan: ReadableSpan = exportSpy.args[5][0][0];
+            const componentDidUpdateSpan: ReadableSpan = exportSpy.args[6][0][0];
+            const updatingSpan: ReadableSpan = exportSpy.args[7][0][0];
+      
+            assert.equal(
+              updatingSpan.parentSpanId, 
+              undefined, 
+              'updating span is should not have a parent'
+            );
+            assert.equal(
+              forceUpdateSpan.parentSpanId, 
+              updatingSpan.spanContext.spanId, 
+              'forceUpdate span is not a child of the updating span'
+            );
+            assert.equal(
+              renderSpan.parentSpanId, 
+              updatingSpan.spanContext.spanId, 
+              'render span is not a child of the updating span'
+            );
+            assert.equal(
+              getSnapshotBeforeUpdateSpan.parentSpanId, 
+              updatingSpan.spanContext.spanId, 
+              'getSnapshotBeforeUpdate span is not a child of the updating span'
+            );
+            assert.equal(
+              componentDidUpdateSpan.parentSpanId,
+              updatingSpan.spanContext.spanId, 
+              'componentDidUpdate span is not a child of the updating span'
+            );
+
+            assert.strictEqual(exportSpy.args.length, 8, `total number of spans is wrong`);
+          });
+
+          it('spans should have correct name', () => {
+            const forceUpdateSpan: ReadableSpan = exportSpy.args[3][0][0];
+            const renderSpan: ReadableSpan = exportSpy.args[4][0][0];
+            const getSnapshotBeforeUpdateSpan: ReadableSpan = exportSpy.args[5][0][0];
+            const componentDidUpdateSpan: ReadableSpan = exportSpy.args[6][0][0];
+            const updatingSpan: ReadableSpan = exportSpy.args[7][0][0];
+  
+            assert.equal(updatingSpan.name, 'reactLoad: updating', 'updating span has wrong name');
+            assert.equal(forceUpdateSpan.name, 'forceUpdate()', 'forceUpdate span has wrong name');
+            assert.equal(renderSpan.name, 'render', 'render span has wrong name');
+            assert.equal(getSnapshotBeforeUpdateSpan.name, 'getSnapshotBeforeUpdate', 'getSnapshotBeforeUpdate span has wrong name');
+            assert.equal(componentDidUpdateSpan.name, 'componentDidUpdate', 'componentDidUpdate span has wrong name');
+          });
+
+          it('spans should have correct attributes', () => {
+            const spans: [] = exportSpy.args;
+            spans.forEach(element => {
+              const span: ReadableSpan = element[0][0];
+              const attributes = span.attributes;
+              const keys = Object.keys(attributes);
+
+              assert.ok(
+                attributes[keys[0]] !== '',
+                `attributes ${GeneralAttribute.COMPONENT} is not defined for span "${span.name}"`
+              );
+
+              assert.ok(
+                attributes[keys[1]] !== '',
+                `attributes ${AttributeNames.LOCATION_URL} is not defined for span "${span.name}"`
+              );
+
+              assert.ok(
+                attributes[keys[2]] !== '',
+                `attributes ${AttributeNames.REACT_NAME} is not defined for span "${span.name}"`
+              );
+
+              assert.ok(
+                attributes[keys[3]] !== '',
+                `attributes ${AttributeNames.REACT_STATE} is not defined for span "${span.name}"`
+              );
+
+              assert.strictEqual(keys.length, 4, `number of attributes is wrong for span "${span.name}"`);
+            });
+          });
+        });
+      });
+    });
+
+    describe('when updating AND shouldComponentUpdate returns false', () => {
+      beforeEach(() => {
+        reactPlugin = new ReactLoad([ShouldComponentUpdateFalse]);
+        reactPlugin.enable(moduleExports, provider, logger);
+        rootContainer = document.createElement("div");
+        document.body.appendChild(rootContainer);
+        var reactElement = React.createElement(ShouldComponentUpdateFalse, null, null);
+        act(() => {
+          let reactComponent = ReactDOM.render(reactElement, rootContainer);
+          reactComponent.setState({test: 'newState'});
+        });
+      });
+
+      afterEach(() => {
+        document.body.removeChild(rootContainer);
+        rootContainer = null;
+      });
+
+      it('should export spans setState() and shouldComponentUpdate as children', () => {
+        const setStateSpan: ReadableSpan = exportSpy.args[3][0][0];
+        const shouldComponentUpdateSpan: ReadableSpan = exportSpy.args[4][0][0];
+        const updatingSpan: ReadableSpan = exportSpy.args[5][0][0];
+  
+        assert.equal(
+          updatingSpan.parentSpanId, 
+          undefined, 
+          'updating span is should not have a parent'
+        );
+        assert.equal(
+          setStateSpan.parentSpanId, 
+          updatingSpan.spanContext.spanId, 
+          'setState span is not a child of the updating span'
+        );
+        assert.equal(
+          shouldComponentUpdateSpan.parentSpanId, 
+          updatingSpan.spanContext.spanId, 
+          'shouldComponentUpdate span is not a child of the updating span'
+        );
+       
+        assert.strictEqual(exportSpy.args.length, 6, `total number of spans is wrong`);
+      });
+
+      it('spans should have correct name', () => {
+        const setStateSpan: ReadableSpan = exportSpy.args[3][0][0];
+        const shouldComponentUpdateSpan: ReadableSpan = exportSpy.args[4][0][0];
+        const updatingSpan: ReadableSpan = exportSpy.args[5][0][0];
+
+        assert.equal(updatingSpan.name, 'reactLoad: updating', 'updating span has wrong name');
+        assert.equal(setStateSpan.name, 'setState()', 'setState span has wrong name');
+        assert.equal(shouldComponentUpdateSpan.name, 'shouldComponentUpdate', 'shouldComponentUpdate span has wrong name');
+      });
+
+      it('spans should have correct attributes', () => {
+        const spans: [] = exportSpy.args;
+        spans.forEach(element => {
+          const span: ReadableSpan = element[0][0];
+          const attributes = span.attributes;
+          const keys = Object.keys(attributes);
+
+          assert.ok(
+            attributes[keys[0]] !== '',
+            `attributes ${GeneralAttribute.COMPONENT} is not defined for span "${span.name}"`
+          );
+
+          assert.ok(
+            attributes[keys[1]] !== '',
+            `attributes ${AttributeNames.LOCATION_URL} is not defined for span "${span.name}"`
+          );
+
+          assert.ok(
+            attributes[keys[2]] !== '',
+            `attributes ${AttributeNames.REACT_NAME} is not defined for span "${span.name}"`
+          );
+
+          assert.ok(
+            attributes[keys[3]] !== '',
+            `attributes ${AttributeNames.REACT_STATE} is not defined for span "${span.name}"`
+          );
+
+          assert.strictEqual(keys.length, 4, `number of attributes is wrong for span "${span.name}"`);
         });
       });
     });

--- a/plugins/web/opentelemetry-plugin-react-load/test/test-react-components/AllLifecycles.tsx
+++ b/plugins/web/opentelemetry-plugin-react-load/test/test-react-components/AllLifecycles.tsx
@@ -6,11 +6,9 @@ export default class AllLifecycles extends React.Component {
     }
 
     componentDidMount(){
-        console.log("mounted");
     }
 
     componentDidUpdate(prevProps: any){
-        console.log("updated");
     }
 
     shouldComponentUpdate(nextProps: any, nextState: any){

--- a/plugins/web/opentelemetry-plugin-react-load/test/test-react-components/AllLifecycles.tsx
+++ b/plugins/web/opentelemetry-plugin-react-load/test/test-react-components/AllLifecycles.tsx
@@ -9,6 +9,18 @@ export default class AllLifecycles extends React.Component {
         console.log("mounted");
     }
 
+    componentDidUpdate(prevProps: any){
+        console.log("updated");
+    }
+
+    shouldComponentUpdate(nextProps: any, nextState: any){
+        return true;
+    }
+    
+    getSnapshotBeforeUpdate(prevProps: any, prevState: any){
+        return null;
+    }
+
     render() {
         return(
             <div></div>

--- a/plugins/web/opentelemetry-plugin-react-load/test/test-react-components/MissingComponentDidMount.tsx
+++ b/plugins/web/opentelemetry-plugin-react-load/test/test-react-components/MissingComponentDidMount.tsx
@@ -6,7 +6,6 @@ export default class MissingComponentDidMount extends React.Component {
     }
 
     componentDidUpdate(prevProps: any){
-        console.log("updated");
     }
 
     shouldComponentUpdate(nextProps: any, nextState: any){

--- a/plugins/web/opentelemetry-plugin-react-load/test/test-react-components/MissingComponentDidUpdate.tsx
+++ b/plugins/web/opentelemetry-plugin-react-load/test/test-react-components/MissingComponentDidUpdate.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 
-export default class MissingComponentDidMount extends React.Component {
+export default class MissingComponentDidUpdate extends React.Component {
     constructor(props: Readonly<{}>){
         super(props);
     }
 
-    componentDidUpdate(prevProps: any){
-        console.log("updated");
+    componentDidMount(){
+        console.log("mounted");
     }
 
     shouldComponentUpdate(nextProps: any, nextState: any){

--- a/plugins/web/opentelemetry-plugin-react-load/test/test-react-components/MissingComponentDidUpdate.tsx
+++ b/plugins/web/opentelemetry-plugin-react-load/test/test-react-components/MissingComponentDidUpdate.tsx
@@ -6,7 +6,6 @@ export default class MissingComponentDidUpdate extends React.Component {
     }
 
     componentDidMount(){
-        console.log("mounted");
     }
 
     shouldComponentUpdate(nextProps: any, nextState: any){

--- a/plugins/web/opentelemetry-plugin-react-load/test/test-react-components/MissingGetSnapshotBeforeUpdate.tsx
+++ b/plugins/web/opentelemetry-plugin-react-load/test/test-react-components/MissingGetSnapshotBeforeUpdate.tsx
@@ -6,11 +6,9 @@ export default class MissingGetSnapshotBeforeUpdate extends React.Component {
     }
 
     componentDidMount(){
-        console.log("mounted");
     }
 
     componentDidUpdate(prevProps: any){
-        console.log("updated");
     }
 
     shouldComponentUpdate(nextProps: any, nextState: any){

--- a/plugins/web/opentelemetry-plugin-react-load/test/test-react-components/MissingGetSnapshotBeforeUpdate.tsx
+++ b/plugins/web/opentelemetry-plugin-react-load/test/test-react-components/MissingGetSnapshotBeforeUpdate.tsx
@@ -1,8 +1,12 @@
 import * as React from 'react';
 
-export default class MissingComponentDidMount extends React.Component {
+export default class MissingGetSnapshotBeforeUpdate extends React.Component {
     constructor(props: Readonly<{}>){
         super(props);
+    }
+
+    componentDidMount(){
+        console.log("mounted");
     }
 
     componentDidUpdate(prevProps: any){
@@ -11,10 +15,6 @@ export default class MissingComponentDidMount extends React.Component {
 
     shouldComponentUpdate(nextProps: any, nextState: any){
         return true;
-    }
-    
-    getSnapshotBeforeUpdate(prevProps: any, prevState: any){
-        return null;
     }
 
     render() {

--- a/plugins/web/opentelemetry-plugin-react-load/test/test-react-components/MissingRender.tsx
+++ b/plugins/web/opentelemetry-plugin-react-load/test/test-react-components/MissingRender.tsx
@@ -6,11 +6,9 @@ export default class MissingRender extends React.Component {
     }
 
     componentDidMount(){
-        console.log("mounted");
     }
 
     componentDidUpdate(prevProps: any){
-        console.log("updated");
     }
 
     shouldComponentUpdate(nextProps: any, nextState: any){

--- a/plugins/web/opentelemetry-plugin-react-load/test/test-react-components/MissingRender.tsx
+++ b/plugins/web/opentelemetry-plugin-react-load/test/test-react-components/MissingRender.tsx
@@ -8,4 +8,17 @@ export default class MissingRender extends React.Component {
     componentDidMount(){
         console.log("mounted");
     }
+
+    componentDidUpdate(prevProps: any){
+        console.log("updated");
+    }
+
+    shouldComponentUpdate(nextProps: any, nextState: any){
+        return true;
+    }
+    
+    getSnapshotBeforeUpdate(prevProps: any, prevState: any){
+        return null;
+    }
+
 }

--- a/plugins/web/opentelemetry-plugin-react-load/test/test-react-components/MissingShouldComponentUpdate.tsx
+++ b/plugins/web/opentelemetry-plugin-react-load/test/test-react-components/MissingShouldComponentUpdate.tsx
@@ -6,11 +6,9 @@ export default class MisingShouldComponentUpdate extends React.Component {
     }
 
     componentDidMount(){
-        console.log("mounted");
     }
 
     componentDidUpdate(prevProps: any){
-        console.log("updated");
     }
 
     getSnapshotBeforeUpdate(prevProps: any, prevState: any){

--- a/plugins/web/opentelemetry-plugin-react-load/test/test-react-components/MissingShouldComponentUpdate.tsx
+++ b/plugins/web/opentelemetry-plugin-react-load/test/test-react-components/MissingShouldComponentUpdate.tsx
@@ -1,21 +1,22 @@
 import * as React from 'react';
 
-export default class MissingComponentDidMount extends React.Component {
+export default class MisingShouldComponentUpdate extends React.Component {
     constructor(props: Readonly<{}>){
         super(props);
+    }
+
+    componentDidMount(){
+        console.log("mounted");
     }
 
     componentDidUpdate(prevProps: any){
         console.log("updated");
     }
 
-    shouldComponentUpdate(nextProps: any, nextState: any){
-        return true;
-    }
-    
     getSnapshotBeforeUpdate(prevProps: any, prevState: any){
         return null;
     }
+
 
     render() {
         return(

--- a/plugins/web/opentelemetry-plugin-react-load/test/test-react-components/ShouldComponentUpdateFalse.tsx
+++ b/plugins/web/opentelemetry-plugin-react-load/test/test-react-components/ShouldComponentUpdateFalse.tsx
@@ -1,8 +1,12 @@
 import * as React from 'react';
 
-export default class MissingComponentDidMount extends React.Component {
+export default class ShouldComponentUpdateFalse extends React.Component {
     constructor(props: Readonly<{}>){
         super(props);
+    }
+
+    componentDidMount(){
+        console.log("mounted");
     }
 
     componentDidUpdate(prevProps: any){
@@ -10,7 +14,7 @@ export default class MissingComponentDidMount extends React.Component {
     }
 
     shouldComponentUpdate(nextProps: any, nextState: any){
-        return true;
+        return false;
     }
     
     getSnapshotBeforeUpdate(prevProps: any, prevState: any){

--- a/plugins/web/opentelemetry-plugin-react-load/test/test-react-components/ShouldComponentUpdateFalse.tsx
+++ b/plugins/web/opentelemetry-plugin-react-load/test/test-react-components/ShouldComponentUpdateFalse.tsx
@@ -6,11 +6,9 @@ export default class ShouldComponentUpdateFalse extends React.Component {
     }
 
     componentDidMount(){
-        console.log("mounted");
     }
 
     componentDidUpdate(prevProps: any){
-        console.log("updated");
     }
 
     shouldComponentUpdate(nextProps: any, nextState: any){


### PR DESCRIPTION
## Short description of the changes

- This PR adds updating flow logic
ex span:
![image](https://user-images.githubusercontent.com/33324099/87096112-1bce6d80-c210-11ea-85b6-c35a8b3e7be9.png)
![image](https://user-images.githubusercontent.com/33324099/87096139-25f06c00-c210-11ea-9819-cac93de97452.png)
